### PR TITLE
Document access to unix sockets.

### DIFF
--- a/content/features/1-connecting.mdx
+++ b/content/features/1-connecting.mdx
@@ -90,6 +90,20 @@ client.query('SELECT NOW()', (err, res) => {
 })
 ```
 
+### Programmatic Connection to Sockets
+
+Connections to unix sockets can also be made. This can be useful on distros like Ubuntu, where authentication is managed via the socket connection instead of a password.
+
+```js
+const { Client } = require('pg');
+client = new Client({
+    host: '/cloudsql/myproject:zone:mydb'
+    username: 'username',
+    password: 'password',
+    database: 'database_name',
+});
+```
+
 ## Connection URI
 
 You can initialize both a pool and a client with a connection string URI as well. This is common in environments like Heroku where the database connection string is supplied to your application dyno through an environment variable. Connection string parsing brought to you by [pg-connection-string](https://github.com/iceddev/pg-connection-string).


### PR DESCRIPTION
Should fix [this issue](https://github.com/brianc/node-postgres/issues/1617) asking for better docs concerning the use of unix sockets. Seems to be a common issue and the issue is over a year old.