### PR TITLE
To prevent intermediate value is not a function

### DIFF
--- a/content/features/4-transactions.mdx
+++ b/content/features/4-transactions.mdx
@@ -71,7 +71,8 @@ Things are considerably more straightforward if you're using async/await:
 
 ```js
 const { Pool } = require('pg')
-const pool = new Pool()(async () => {
+const pool = new Pool()
+;(async () => {
   // note: we don't try/catch this because if connecting throws an exception
   // we don't need to dispose of the client (it will be undefined)
   const client = await pool.connect()


### PR DESCRIPTION
It's the one place you need a semicolon, otherwise you get the error:`(intermediate value) is not a function`