### PR TITLE
docs(2-client.mdx): fix typo 'e => err.stack' -> 'err => err.stack'

### DIFF
--- a/content/api/2-client.mdx
+++ b/content/api/2-client.mdx
@@ -63,7 +63,7 @@ const client = new Client()
 client
   .connect()
   .then(() => console.log('connected'))
-  .catch(e => console.error('connection error', err.stack))
+  .catch(err => console.error('connection error', err.stack))
 ```
 
 _note: connect returning a promise only available in pg@7.0 or above_


### PR DESCRIPTION
I fixed some typo  😊

I always thank you for what you made.👍