### PR TITLE
Fix typo in transaction async/await example

### DIFF
--- a/content/features/4-transactions.mdx
+++ b/content/features/4-transactions.mdx
@@ -80,7 +80,7 @@ const pool = new Pool()
   try {
     await client.query('BEGIN')
     const queryText = 'INSERT INTO users(name) VALUES($1) RETURNING id'
-    const { rows } = await client.query(queryText, ['brianc'])
+    const res = await client.query(queryText, ['brianc'])
 
     const insertPhotoText = 'INSERT INTO photos(user_id, photo_url) VALUES ($1, $2)'
     const insertPhotoValues = [res.rows[0].id, 's3.bucket.foo']


### PR DESCRIPTION
The `insertPhotoValues` variable on line 86 referenced `res` which is not declared. It should be declared on line 83 but is destructured into `rows`.

I chose to revert the destructured version to `res` so the syntax will look similar to the callback example above :)