### PR TITLE
Fixed syntax error in 3-pooling.mdx

### DIFF
--- a/content/features/3-pooling.mdx
+++ b/content/features/3-pooling.mdx
@@ -147,7 +147,7 @@ const pool = new Pool()
 (async () => {
   console.log('starting async query')
   const result = await pool.query('SELECT NOW()')
-  console.log('async query finished)
+  console.log('async query finished')
 
   console.log('starting callback query')
   pool.query('SELECT NOW()', (err, res) => {


### PR DESCRIPTION
Updated "console.log('async query finished)" to "console.log('async query finished')"