### PR TITLE
Fix build error

### DIFF
--- a/src/sortNavItems.js
+++ b/src/sortNavItems.js
@@ -23,14 +23,11 @@ export default function getSortedNavItems(allMdx) {
           slug: cur,
           filename: fields.filename.name,
         }
-        if (forcedNavOrder.find(url => url === cur)) {
-          return { ...acc, [cur]: [newItem] }
-        }
+        
+        const prefix = '/' + cur.split('/')[1]
 
-        const prefix = cur.split('/')[1]
-
-        if (prefix && forcedNavOrder.find(url => url === `/${prefix}`)) {
-          return { ...acc, [`/${prefix}`]: [...acc[`/${prefix}`], { ...newItem }] }
+        if (forcedNavOrder.some(url => url === prefix)) {
+          return { ...acc, [prefix]: [...acc[prefix] || [], { ...newItem }] }
         } else {
           return { ...acc, items: [...acc.items, newItem] }
         }


### PR DESCRIPTION
I just realized my PR failed to build to prod, thought I'l fix it :)

I fixed the part where the error occurred, and refactored a bit.

Explanation:
I found that `allMdx.edges` doesn't always return in the same order. The previous code expects it to be in the order, e,g, '/', '/api', '/api/pool'. The root or prefix paths are expected to come before the subpaths. This means if the order becomes e.g. '/', '/api/pool', '/api', it would fail due to line 33 `...acc[`/${prefix}`` failed to spread since it wasn't declared before.

Also, I found that after editing the changes, line 26-28's if statement can be combined into the changes below.