### PR TITLE
Use page title and site title in title tag

### DIFF
--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -84,7 +84,7 @@ export default class MDXRuntimeTest extends Component {
     const nav = getSortedNavItems(allMdx).filter(x => !x.hasChildren)
 
     // meta tags
-    const metaTitle = mdx.frontmatter.metaTitle
+    const metaTitle = mdx.fields.title
     const metaDescription = mdx.frontmatter.metaDescription
     let canonicalUrl = config.gatsby.siteUrl
     canonicalUrl = config.gatsby.pathPrefix !== '/' ? canonicalUrl + config.gatsby.pathPrefix : canonicalUrl
@@ -93,7 +93,11 @@ export default class MDXRuntimeTest extends Component {
     return (
       <Layout {...this.props}>
         <Helmet>
-          {metaTitle ? <title>{metaTitle}</title> : null}
+          {metaTitle ? (
+            <title>
+              {metaTitle} | {title}
+            </title>
+          ) : null}
           {metaTitle ? <meta name="title" content={metaTitle} /> : null}
           {metaDescription ? <meta name="description" content={metaDescription} /> : null}
           {metaTitle ? <meta property="og:title" content={metaTitle} /> : null}


### PR DESCRIPTION
Updates the code to set the title tag based on page titles instead of `metaTitle` of which only the Native page had one with a value of `bar`. 

Before:
<img width="245" alt="Screen Shot 2019-10-19 at 12 39 03 PM" src="https://user-images.githubusercontent.com/4588318/67148495-2a35bd00-f26e-11e9-9691-c4808afc1bfe.png">

After:
<img width="240" alt="Screen Shot 2019-10-19 at 12 38 49 PM" src="https://user-images.githubusercontent.com/4588318/67148498-2d30ad80-f26e-11e9-902f-a051003709c6.png">
