### PR TITLE
Confusion – cursor.read(...)  Query(cursor).read(...)

### DIFF
--- a/content/api/5-cursor.mdx
+++ b/content/api/5-cursor.mdx
@@ -26,8 +26,8 @@ const client = await pool.connect()
 const text = 'SELECT * FROM my_large_table WHERE something > $1'
 const values = [10]
 
-const cursor = client.query(new Cursor(text, values))
-
+const cursor = new Cursor(text, values)
+const query = client.query(cursor);
 cursor.read(100, (err, rows) => {
   cursor.close(() => {
     client.release()
@@ -62,7 +62,8 @@ const Cursor = require('pg-cursor')
 
 const pool = new Pool()
 const client = await pool.connect()
-const cursor = client.query(new Cursor('select * from generate_series(0, 5)'))
+const cursor = new Cursor('select * from generate_series(0, 5)')
+const query = client.query(cursor);
 cursor.read(100, (err, rows) => {
   if (err) {
     throw err


### PR DESCRIPTION
I think this might have changed somewhere along the road.

I definitely get when I do `query(cursor).read(...)`,
```
(node:17795) UnhandledPromiseRejectionWarning: TypeError: cursor.read is not a function
    at postgres.connect.then (/root/scraper/interpret_scaped_data.js:69:10)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```

And

`query(cursor).then((cursor) => {cursor.read(...)})` doesn't work the promise never gets there.