### PR TITLE
Made every arg in pool.connect callback optional

### DIFF
--- a/content/api/1-pool.mdx
+++ b/content/api/1-pool.mdx
@@ -45,7 +45,7 @@ const pool = new Pool({
 
 ## pool.connect
 
-### `pool.connect(callback: (err?: Error, client: pg.Client, release: releaseCallback) => void) => void`
+### `pool.connect(callback: (err?: Error, client?: pg.Client, release?: releaseCallback) => void) => void`
 
 Acquires a client from the pool. If the pool is 'full' and all clients are currently checked out, this will wait in a FIFO queue until a client becomes available by it being released back to the pool. If there are idle clients in the pool it will be returned to the callback on `process.nextTick`. If the pool is not full a new client will be created & returned to this callback.
 


### PR DESCRIPTION
All 3 arguments in the connect callback can be undefined, see relevant change to types here for a link to the instances in the relevant source code/tests.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41519