### PR TITLE
Add note to client docs for tls.connect options

### DIFF
--- a/content/api/2-client.mdx
+++ b/content/api/2-client.mdx
@@ -16,7 +16,7 @@ config = {
   database?: string, // default process.env.PGDATABASE || process.env.USER
   port?: number, // default process.env.PGPORT
   connectionString?: string, // e.g. postgres://user:password@host:5432/database
-  ssl?: any, // passed directly to node.TLSSocket
+  ssl?: any, // passed directly to node.TLSSocket, supports all tls.connect options
   types?: any, // custom type parsers
   statement_timeout?: number, // number of milliseconds before a statement in query will time out, default is no timeout
   query_timeout?: number, // number of milliseconds before a query call will timeout, default is no timeout


### PR DESCRIPTION
Why:
node-postgres 8.0.0 introduced support for all tls.connect options for config.ssl.

This commit:
Makes reference to this in the Client constructor documentation.