### PR TITLE
Update connectionTimeoutMillis references

### DIFF
--- a/content/api/1-pool.mdx
+++ b/content/api/1-pool.mdx
@@ -14,10 +14,6 @@ config = {
   // all valid client config options are also valid here
   // in addition here are the pool specific configuration parameters:
 
-  // number of milliseconds to wait before timing out when connecting a new client
-  // by default this is 0 which means no timeout
-  connectionTimeoutMillis?: int,
-
   // number of milliseconds a client must sit idle in the pool and not be checked out
   // before it is disconnected from the backend and discarded
   // default is 10000 (10 seconds) - set to 0 to disable auto-disconnection of idle clients

--- a/content/api/2-client.mdx
+++ b/content/api/2-client.mdx
@@ -20,6 +20,7 @@ config = {
   types?: any, // custom type parsers
   statement_timeout?: number, // number of milliseconds before a statement in query will time out, default is no timeout
   query_timeout?: number, // number of milliseconds before a query call will timeout, default is no timeout
+  connectionTimeoutMillis?: number, // number of milliseconds before timing out when connecting, default is no timeout
 }
 ```
 


### PR DESCRIPTION
While using node-postgres I noticed that connectionTimeoutMillis actually applies to the Client and Pool, while the docs indicate it's Pool specific.

I've added this option to Client page, and removed it from Pool as it would now be covered by "all valid client config options are also valid here".