### PR TITLE
fix: variable names in map fn for query examples

### DIFF
--- a/content/features/2-queries.mdx
+++ b/content/features/2-queries.mdx
@@ -182,7 +182,7 @@ client.query(query, (err, res) => {
   if (err) {
     console.log(err.stack)
   } else {
-    console.log(res.fields.map(f => field.name)) // ['first_name', 'last_name']
+    console.log(res.fields.map(field => field.name)) // ['first_name', 'last_name']
     console.log(res.rows[0]) // ['Brian', 'Carlson']
   }
 })
@@ -191,7 +191,7 @@ client.query(query, (err, res) => {
 client
   .query(query)
   .then(res => {
-    console.log(res.fields.map(f => field.name)) // ['first_name', 'last_name']
+    console.log(res.fields.map(field => field.name)) // ['first_name', 'last_name']
     console.log(res.rows[0]) // ['Brian', 'Carlson']
   })
   .catch(e => console.error(e.stack))


### PR DESCRIPTION
Copied code, didn't work. Fixed. Submitted.

Good job otherwise! :100: 