### PR TITLE
Include 8.0 in the Upgrading section

### DIFF
--- a/content/guides/3-upgrading.md
+++ b/content/guides/3-upgrading.md
@@ -1,7 +1,25 @@
 ---
-title: Upgrading to 7.0
+title: Upgrading
 slug: /guides/upgrading
 ---
+
+# Upgrading to 8.0
+
+node-postgres at 8.0 introduces a breaking change to ssl-verified connetions.  If you connect with ssl and use
+
+```
+const client = new Client({ ssl: true })
+```
+
+and the server's SSL certificate is self-signed, connections will fail as of node-postgres 8.0.  To keep the existing behavior, modify the invocation to
+
+```
+const client = new Client({ ssl: { rejectUnauthorized: false } })
+```
+
+The rest of the changes are relatively minor and unlikely to cause issues; see [the announcement](/announcements#2020-02-25) for full details.
+
+# Upgrading to 7.0
 
 node-postgres at 7.0 introduces somewhat significant breaking changes to the public API.
 


### PR DESCRIPTION
This is where I went looking for information about what broke in 8.
@eschwartz pointed me to the Announcements, which do contain full
details but were not a place I thought to look.

This PR includes the most critical breaking change in the "Upgrading"
section, with reference to the announcement for the details.

Fixes https://github.com/brianc/node-postgres/issues/2342