### PR TITLE
Remove Semicolon In Wrong Location (Index Page)

### DIFF
--- a/content/welcome.mdx
+++ b/content/welcome.mdx
@@ -34,7 +34,7 @@ This is the simplest possible way to connect, query, and disconnect with async/a
 const { Client } = require('pg')
 const client = new Client()
 
-;(async () => {
+(async () => {
   await client.connect()
 
   const res = await client.query('SELECT $1::text as message', ['Hello world!'])


### PR DESCRIPTION
A semicolon was placed at the beginning of line 37. It was not required and could be considered an error. It has been removed.