### PR TITLE
Document idle_in_transaction_session_timeout

### DIFF
--- a/content/api/2-client.mdx
+++ b/content/api/2-client.mdx
@@ -22,6 +22,7 @@ config = {
   statement_timeout?: number, // number of milliseconds before a statement in query will time out, default is no timeout
   query_timeout?: number, // number of milliseconds before a query call will timeout, default is no timeout
   connectionTimeoutMillis?: number, // number of milliseconds to wait for connection, default is no timeout
+  idle_in_transaction_session_timeout?: number // number of milliseconds before terminating any session with an open idle connection, default is no timeout
 }
 ```
 

--- a/content/api/2-client.mdx
+++ b/content/api/2-client.mdx
@@ -22,7 +22,7 @@ config = {
   statement_timeout?: number, // number of milliseconds before a statement in query will time out, default is no timeout
   query_timeout?: number, // number of milliseconds before a query call will timeout, default is no timeout
   connectionTimeoutMillis?: number, // number of milliseconds to wait for connection, default is no timeout
-  idle_in_transaction_session_timeout?: number // number of milliseconds before terminating any session with an open idle connection, default is no timeout
+  idle_in_transaction_session_timeout?: number // number of milliseconds before terminating any session with an open idle transaction, default is no timeout
 }
 ```
 


### PR DESCRIPTION
Simple documentation for the pass-through connection parameter added
in https://github.com/brianc/node-postgres/pull/2049.

The description is taken from https://www.postgresql.org/docs/current/runtime-config-client.html.

Closes https://github.com/brianc/node-postgres/issues/2381