### PR TITLE
Remove invalid trailing comma in date example

### DIFF
--- a/content/features/5-types.mdx
+++ b/content/features/5-types.mdx
@@ -59,7 +59,7 @@ const createTableText = `
 CREATE TEMP TABLE dates(
   date_col DATE,
   timestamp_col TIMESTAMP,
-  timestamptz_col TIMESTAMPTZ,
+  timestamptz_col TIMESTAMPTZ
 );
 `
 // create our temp table


### PR DESCRIPTION
This commit removes an extra trailing comma the [snippet][docs] that demonstrates date/timestamp/timestamptz conversion. Copy/pasting the example caused a SQL syntax error.

[docs]: https://node-postgres.com/features/types