### PR TITLE
remove error argument from close callback

### DIFF
--- a/content/api/5-cursor.mdx
+++ b/content/api/5-cursor.mdx
@@ -76,6 +76,6 @@ cursor.read(100, (err, rows) => {
 
 ## close
 
-### `cursor.close(callback: (err: Error) => void) => void`
+### `cursor.close(callback: () => void) => void`
 
 Used to close the cursor early. If you want to stop reading from the cursor before you get all of the rows returned, call this.


### PR DESCRIPTION
The callback is never called with [any argument at all](https://github.com/brianc/node-postgres/blob/master/packages/pg-cursor/index.js#L198-L214) and docs is misleading/outdated.