### PR TITLE
Warn about mixed use of connectionString and ssl

### DIFF
--- a/content/features/6-ssl.mdx
+++ b/content/features/6-ssl.mdx
@@ -44,3 +44,18 @@ pool
   .catch(err => console.error('error connecting', err.stack))
   .then(() => pool.end())
 ```
+
+## Usage with `connectionString`
+
+If you plan to use a combination of a database connection string from the environment and SSL settings in the config object directly, then you must avoid including any of `sslcert`, `sslkey`, `sslrootcert`, or `sslmode` in the connection string. If any of these options are used then the `ssl` object is replaced and any additional options provided there will be lost.
+
+```js
+const config = {
+  connectionString: 'postgres://user:password@host:port/db?sslmode=require',
+  // Beware! The ssl object is overwritten when parsing the connectionString
+  ssl: {
+    rejectUnauthorized: false,
+    ca: fs.readFileSync('/path/to/server-certificates/root.crt').toString(),
+  },
+}
+```


### PR DESCRIPTION
I tripped over this case today when handling client code which used both `connectionString` and `ssl` configuration options and the former unexpectedly overrides the latter.

The relevant code that handles this is here:
https://github.com/brianc/node-postgres/blob/4b229275cfe41ca17b7d69bd39f91ada0068a5d0/packages/pg-connection-string/index.js#L68-L70

Other people with similar confusion:
https://github.com/brianc/node-postgres/issues/2375
https://github.com/brianc/node-postgres/issues/2380