### PR TITLE
Added function to password property type of config

### DIFF
--- a/content/api/2-client.mdx
+++ b/content/api/2-client.mdx
@@ -12,7 +12,7 @@ Every field of the `config` object is entirely optional. A `Client` instance wil
 ```flow
 config = {
   user?: string, // default process.env.PGUSER || process.env.USER
-  password?: string, //default process.env.PGPASSWORD
+  password?: string or function, //default process.env.PGPASSWORD
   host?: string, // default process.env.PGHOST
   database?: string, // default process.env.PGDATABASE || process.env.USER
   port?: number, // default process.env.PGPORT


### PR DESCRIPTION
Hi.
There is a problem with the constructor configuration of pg.Client (pg.Poll).

We would like you to reflect this fix so that you will soon notice that you can specify a dynamic password by specifying a function in the password property.