### PR TITLE
Updated express example, now working.

### DIFF
--- a/content/guides/1-project-structure.md
+++ b/content/guides/1-project-structure.md
@@ -49,11 +49,11 @@ That's it. But now everywhere else in my application instead of requiring `pg` d
 const db = require('../db')
 
 app.get('/:id', (req, res, next) => {
-  db.query('SELECT * FROM users WHERE id = $1', [req.params.id], (err, res) => {
+  db.query('SELECT * FROM users WHERE id = $1', [req.params.id], (err, result) => {
     if (err) {
       return next(err)
     }
-    res.send(res.rows[0])
+    res.send(result.rows[0])
   })
 })
 


### PR DESCRIPTION
There are two variables named `res`. Fails responding back to user because it's using res from db instance. Renamed to `result` and it's now a working example.