### PR TITLE
Fix typo in pg.Result documentation

### DIFF
--- a/content/api/3-result.mdx
+++ b/content/api/3-result.mdx
@@ -15,7 +15,7 @@ Every result will have a rows array. If no rows are returned the array will be e
 
 ### `result.fields: Array<FieldInfo>`
 
-Every result will have a fields array. This array contains the `name` and `dataTypeId` of each field in the result. These fields are ordered in the same order as the columns if you are using `arrayMode` for the query:
+Every result will have a fields array. This array contains the `name` and `dataTypeID` of each field in the result. These fields are ordered in the same order as the columns if you are using `arrayMode` for the query:
 
 ```js
 const { Pool } = require('pg')


### PR DESCRIPTION
`dataTypeId` -> `dataTypeID`