### PR TITLE
default database name depends on $PGUSER first, then $USER

### DIFF
--- a/content/api/2-client.mdx
+++ b/content/api/2-client.mdx
@@ -14,7 +14,7 @@ config = {
   user?: string, // default process.env.PGUSER || process.env.USER
   password?: string or function, //default process.env.PGPASSWORD
   host?: string, // default process.env.PGHOST
-  database?: string, // default process.env.PGDATABASE || process.env.PGUSER || process.env.USER
+  database?: string, // default process.env.PGDATABASE || user
   port?: number, // default process.env.PGPORT
   connectionString?: string, // e.g. postgres://user:password@host:5432/database
   ssl?: any, // passed directly to node.TLSSocket, supports all tls.connect options

--- a/content/api/2-client.mdx
+++ b/content/api/2-client.mdx
@@ -14,7 +14,7 @@ config = {
   user?: string, // default process.env.PGUSER || process.env.USER
   password?: string or function, //default process.env.PGPASSWORD
   host?: string, // default process.env.PGHOST
-  database?: string, // default process.env.PGDATABASE || process.env.USER
+  database?: string, // default process.env.PGDATABASE || process.env.PGUSER || process.env.USER
   port?: number, // default process.env.PGPORT
   connectionString?: string, // e.g. postgres://user:password@host:5432/database
   ssl?: any, // passed directly to node.TLSSocket, supports all tls.connect options


### PR DESCRIPTION
If I get this right, the spot in the code to know for that is https://github.com/brianc/node-postgres/blob/947ccee346f0d598e135548e1e4936a9a008fc6f/packages/pg/lib/connection-parameters.js#L9