### PR TITLE
Fix connection string syntax errors

### DIFF
--- a/content/features/1-connecting.mdx
+++ b/content/features/1-connecting.mdx
@@ -142,18 +142,14 @@ You can initialize both a pool and a client with a connection string URI as well
 const { Pool, Client } = require('pg')
 const connectionString = 'postgresql://dbuser:secretpassword@database.server.com:3211/mydb'
 
-const pool = new Pool({
-  connectionString,
-})
+const pool = new Pool(connectionString)
 
 pool.query('SELECT NOW()', (err, res) => {
   console.log(err, res)
   pool.end()
 })
 
-const client = new Client({
-  connectionString,
-})
+const client = new Client(connectionString)
 client.connect()
 
 client.query('SELECT NOW()', (err, res) => {


### PR DESCRIPTION
Remove an extra set of curly braces to fix a syntax error that occurred when trying to create a Pool or Client from a connection string.