### PR TITLE
Add Sequelize SSL config format

### DIFF
--- a/content/features/6-ssl.mdx
+++ b/content/features/6-ssl.mdx
@@ -59,3 +59,23 @@ const config = {
   },
 }
 ```
+
+## Note
+With Sequelize you may actually need to store the SSL information one level below the other connection information, under dialectOptions, like this:
+
+```js
+const config = {
+  username:,
+  password:,
+  database:,
+  host:,
+  dialect: "postgres",
+  dialectOptions: {
+    ssl: {
+      rejectUnauthorized: true,
+      ca: process.env.CA_CERT,
+    },
+  },
+  logging:
+}
+```


### PR DESCRIPTION
I ran into this while trying to make my app connect to DigitalOcean managed Postgres. The issues I had were due to me putting ssl information at the same level as the other config info, as is shown in this document, to which Postgres documentation links. I am sure many others will try the same and miss that SSL info has to be under dialectOptions.